### PR TITLE
docs: Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # zap-prompt
-A simple theme to use with zap<BR>
-It renders [username@hostname] followed by the CWD followed by VCS info (if in a repo dir) 
-![image](https://user-images.githubusercontent.com/82162277/204261229-258926f9-c2c0-4803-8984-9a2e6953b3aa.png)
+A simple theme to use with zap
+<br>
+<br>
+It renders the zap-prompt (⚡ ➜) followed by the CWD followed by VCS info (if in a repo directory) 
+
+![Screenshot from 2023-01-04 11-30-45](https://user-images.githubusercontent.com/84301852/210493582-06808d38-62aa-47b1-a9a9-7b6c25d7620b.png)


### PR DESCRIPTION
I found that the readme file of this repo still talks about atmachine-prompt which has been moved to a separate repo and not about the zap-prompt. 

I've updated the readme and screenshot to zap-prompt. 